### PR TITLE
Improved simple operations

### DIFF
--- a/lamdba.cabal
+++ b/lamdba.cabal
@@ -24,6 +24,7 @@ source-repository head
 
 library
   exposed-modules:
+      BetaReduction
       LambdaCalculus
       Lexer
       Operation

--- a/src/BetaReduction.hs
+++ b/src/BetaReduction.hs
@@ -1,0 +1,66 @@
+module BetaReduction (
+    ReductionResult (
+        Reduced,
+        NormalForm
+    ),
+    ReductionStrategy (
+        NormalOrder,
+        CallByName,
+        CallByValue
+    ),
+    beta,
+) where
+
+import LambdaCalculus
+import Operation
+
+-- Holds a result of beta-reduction.
+data ReductionResult
+    = Reduced LambdaCal
+    | NormalForm LambdaCal
+
+-- A strategy conducting beta-reduction repeatedly.
+data ReductionStrategy
+    = NormalOrder
+    | CallByName
+    | CallByValue
+
+-- Applies a function to the term of the result.
+mapResult :: ReductionResult -> (LambdaCal -> LambdaCal) -> ReductionResult
+mapResult (Reduced term) f = Reduced (f term)
+mapResult (NormalForm term) f = NormalForm (f term)
+
+-- Conducts beta-reduction.
+beta :: ReductionStrategy -> LambdaCal -> ReductionResult
+beta NormalOrder = betaNO
+beta CallByName = betaCN
+beta CallByValue = betaCV
+
+-- Conducts beta-reduction with the normal form strategy.
+betaNO :: LambdaCal -> ReductionResult
+betaNO (Abst name child) = mapResult (betaNO child) (Abst name)
+betaNO (App (Abst name child) replaceTo) = Reduced (replaceVariable name replaceTo child)
+betaNO (App left right) =
+    case betaNO left of
+        Reduced red -> Reduced (App red right)
+        NormalForm _ -> mapResult (betaNO right) (App left)
+betaNO cal = NormalForm cal
+
+-- Conducts beta-reduction with the call by name strategy.
+betaCN :: LambdaCal -> ReductionResult
+betaCN (App (Abst name child) replaceTo) = Reduced (replaceVariable name replaceTo child)
+betaCN (App left right) =
+    case betaCN left of
+        Reduced red -> Reduced (App red right)
+        NormalForm _ -> mapResult (betaCN right) (App left)
+betaCN cal = NormalForm cal
+
+-- Conducts beta-reduction with the call by value strategy.
+betaCV :: LambdaCal -> ReductionResult
+betaCV (App (Abst name1 child1) (Abst name2 child2)) =
+    Reduced (replaceVariable name1 (Abst name2 child2) child1)
+betaCV (App left right) =
+    case betaCV left of
+        Reduced red -> Reduced (App red right)
+        NormalForm _ -> mapResult (betaCV right) (App left)
+betaCV cal = NormalForm cal

--- a/src/Operation.hs
+++ b/src/Operation.hs
@@ -1,9 +1,12 @@
 module Operation (
     replaceVariable,
+    replaceAll,
     betaNO,
     betaCN,
     betaCV,
 ) where
+
+import Data.Bifunctor (Bifunctor(second))
 
 import LambdaCalculus
 
@@ -17,6 +20,26 @@ replaceVariable v replaceTo (Abst name cal)
     | otherwise = Abst name (replaceVariable v replaceTo cal)
 replaceVariable v replaceTo (App left right) =
     App (replaceVariable v replaceTo left) (replaceVariable v replaceTo right)
+
+-- Prepends "!" marks to all of the variables in the term.
+prependMark :: LambdaCal -> LambdaCal
+prependMark (Variable name) = Variable ("!" ++ name)
+prependMark (Abst name child) = Abst name (prependMark child)
+prependMark (App child1 child2) = App (prependMark child1) (prependMark child2)
+
+-- Removes "!" marks from the variables.
+removeMark :: LambdaCal -> LambdaCal
+removeMark (Variable ('!' : rest)) = Variable rest
+removeMark (Variable name) = Variable name
+removeMark (Abst name child) = Abst name (removeMark child)
+removeMark (App child1 child2) = App (removeMark child1) (removeMark child2)
+
+-- Replaces the variables. Don't confuse with `replaceVariable`.
+replaceAll :: [(String, LambdaCal)] -> LambdaCal -> LambdaCal
+replaceAll vars cal =
+    removeMark
+    $ foldl (flip (uncurry replaceVariable)) cal
+    $ map (second prependMark) vars
 
 -- Conducts beta-reduction with the normal form strategy.
 betaNO :: LambdaCal -> LambdaCal

--- a/src/Operation.hs
+++ b/src/Operation.hs
@@ -1,9 +1,6 @@
 module Operation (
     replaceVariable,
     replaceAll,
-    betaNO,
-    betaCN,
-    betaCV,
 ) where
 
 import Data.Bifunctor (Bifunctor(second))
@@ -40,29 +37,3 @@ replaceAll vars cal =
     removeMark
     $ foldl (flip (uncurry replaceVariable)) cal
     $ map (second prependMark) vars
-
--- Conducts beta-reduction with the normal form strategy.
-betaNO :: LambdaCal -> LambdaCal
-betaNO (Abst name child) = Abst name (betaNO child)
-betaNO (App (Abst name child) replaceTo) = replaceVariable name replaceTo child
-betaNO (App left right)
-    | betaNO left /= left = App (betaNO left) right
-    | otherwise = App left (betaNO right)
-betaNO cal = cal
-
--- Conducts beta-reduction with the call by name strategy.
-betaCN :: LambdaCal -> LambdaCal
-betaCN (App (Abst name child) replaceTo) = replaceVariable name replaceTo child
-betaCN (App left right)
-    | betaCN left /= left = App (betaCN left) right
-    | otherwise = App left (betaCN right)
-betaCN cal = cal
-
--- Conducts beta-reduction with the call by value strategy.
-betaCV :: LambdaCal -> LambdaCal
-betaCV (App (Abst name1 child1) (Abst name2 child2)) =
-    replaceVariable name1 (Abst name2 child2) child1
-betaCV (App left right)
-    | betaCV left /= left = App (betaCV left) right
-    | otherwise = App left (betaCV right)
-betaCV cal = cal


### PR DESCRIPTION
- Implemented `replaceAll`, which supports the replacement of metavariables without repetition.
- Achieved the improvement described in #6, that is, distinguishing a term in the normal form from the divergent.