### PR TITLE
Evaluate source files if designated

### DIFF
--- a/app/Configuration.hs
+++ b/app/Configuration.hs
@@ -10,6 +10,7 @@ module Configuration (
     Config,
     ConfigMod,
     unmodified,
+    toConfigMod,
     defaultConfig,
     applyDiff
 ) where
@@ -49,6 +50,14 @@ type ConfigMod = (Diff ReductionStrategy, Diff Context)
 unmodified :: ConfigMod
 
 unmodified = (Unmodified, Unmodified)
+
+--
+-- Converts a configuration into a diff.
+--
+toConfigMod :: Config -> ConfigMod
+
+toConfigMod (strategy, context) =
+    (Modified strategy, Modified context)
 
 --
 -- The default configuration.

--- a/lamdba.cabal
+++ b/lamdba.cabal
@@ -39,6 +39,7 @@ library
   build-depends:
       base >=4.7 && <5
     , haskeline
+    , split
     , tuple
   default-language: Haskell2010
 
@@ -55,6 +56,7 @@ executable lamdba-exe
       base >=4.7 && <5
     , haskeline
     , lamdba
+    , split
     , tuple
   default-language: Haskell2010
 
@@ -70,5 +72,6 @@ test-suite lamdba-test
       base >=4.7 && <5
     , haskeline
     , lamdba
+    , split
     , tuple
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ description:         Please see the README on GitHub at <https://github.com/caph
 dependencies:
 - base >= 4.7 && < 5
 - haskeline
+- split
 - tuple
 
 ghc-options:

--- a/src/Lexer.hs
+++ b/src/Lexer.hs
@@ -26,6 +26,7 @@ data Token
     | LeftParen     -- "("
     | RightParen    -- ")"
     | Command       -- "#"
+    | Text String   -- a text, such as "\"some\""
     deriving Eq
 
 instance Show Token
@@ -43,6 +44,8 @@ instance Show Token
         show RightParen = ")"
 
         show Command = "#"
+
+        show (Text name) = "\"" ++ name ++ "\""
 
 --
 -- Holds a result of lexing.
@@ -84,6 +87,12 @@ tokenize = tokenize' 0
         tokenize' pos (')' : rest) = prependTokens pos RightParen rest
 
         tokenize' pos ('#' : rest) = prependTokens pos Command rest
+
+        tokenize' pos ('"' : rest) =
+            prependTokens pos (Text text) remain
+            where
+                text = takeWhile (/= '"') rest
+                remain = drop 1 $ dropWhile (/= '"') rest
 
         tokenize' pos s
             | token == "" = Error (pos, take 1 s)


### PR DESCRIPTION
Add the `#eval [file]` command to evaluate source codes.