### PR TITLE
Support replacing λ with lmd or \

### DIFF
--- a/src/Lexer.hs
+++ b/src/Lexer.hs
@@ -94,9 +94,13 @@ tokenize = tokenize' 0
                 text = takeWhile (/= '"') rest
                 remain = drop 1 $ dropWhile (/= '"') rest
 
+        tokenize' pos ('\\' : rest) =
+            prependTokens pos Lambda rest
+
         tokenize' pos s
             | token == "" = Error (pos, take 1 s)
             | token == "lambda" = prependTokens pos Lambda next
+            | token == "lmd" = prependTokens pos Lambda next
             | otherwise = prependTokens pos (Ident token) next
             where
                 token = takeWhile isAlphaNum s


### PR DESCRIPTION
It takes too much time to write "lambda" every time I use lamdba, so I want to add abbreviation forms of lambda.